### PR TITLE
Fix behavior of selected answers

### DIFF
--- a/css/arithmetic-quiz.css
+++ b/css/arithmetic-quiz.css
@@ -227,9 +227,13 @@
     width: 29%;
   }
 }
-.h5p-baq-alternatives > .h5p-joubelui-button:active,
-.h5p-baq-alternatives > .h5p-joubelui-button:hover {
+.h5p-baq-alternatives > .h5p-joubelui-button:not(.reveal-correct):not(.reveal-wrong):active,
+.h5p-baq-alternatives > .h5p-joubelui-button:not(.reveal-correct):not(.reveal-wrong):hover {
   background: #005f9b;
+}
+.h5p-baq-alternatives > .h5p-joubelui-button.reveal-correct:hover,
+.h5p-baq-alternatives > .h5p-joubelui-button.reveal-wrong:hover {
+  cursor: default;
 }
 .h5p-baq-alternatives > .h5p-joubelui-button.reveal-correct {
   background: #49837E;

--- a/js/game-page.js
+++ b/js/game-page.js
@@ -431,13 +431,13 @@ H5P.ArithmeticQuiz.GamePage = (function ($, UI, QuizType) {
           }
         },
         'focus': function () {
-          if (self.$button.is('.reveal-correct, reveal-wrong')) {
+          if (self.$button.is('.reveal-correct, .reveal-wrong')) {
             return;
           }
           self.trigger('focus');
         },
         'click': function (event) {
-          if (self.$button.is('.reveal-correct, reveal-wrong')) {
+          if (self.$button.is('.reveal-correct, .reveal-wrong')) {
             return;
           }
           // Answer question


### PR DESCRIPTION
When merged in, once an answer has been selected ...
- the answer buttons for wrong answers properly reject `click` and `focus` events
- the answer buttons stop suggesting they could be interacted with by stopping to show hover/active/pointer states